### PR TITLE
Update paper versions

### DIFF
--- a/prefixes-paper/build.gradle.kts
+++ b/prefixes-paper/build.gradle.kts
@@ -24,7 +24,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("paper")
     changelog.set("https://docs.simplecloud.app/changelog")


### PR DESCRIPTION
This pull request updates the `prefixes-paper/build.gradle.kts` file to include additional Minecraft version support for the Modrinth configuration.

### Modrinth configuration updates:
* Added support for Minecraft versions `1.21.5`, `1.21.6`, `1.21.7`, and `1.21.8` in the `modrinth` block.